### PR TITLE
fix(heterovec): fix type mismatch in with_index generated comparison

### DIFF
--- a/src/heterovec.jl
+++ b/src/heterovec.jl
@@ -490,7 +490,7 @@ The function `f` must not capture variables - pass all data as `args`.
 
     for i in N:-1:1
         result = Expr(:if,
-            :(idx.type_idx === UInt8($i)),
+            :(idx.type_idx === UInt32($i)),
             :(@inbounds f(smv.data[$i][idx.vec_idx], args...)),
             result
         )


### PR DESCRIPTION
## Summary

- `SetKey.type_idx` was changed from `UInt8` to `UInt32` for LLVM/SPIR-V compatibility, but the `@generated` `with_index` function still compared against `UInt8` literals
- Since Julia's `===` checks both value and type, `UInt32(1) === UInt8(1)` is always `false`, causing all branches to fall through to the default (first material)
- This made every object render with the same material regardless of its actual assigned material

## How these changes were tested

- Rendered a scene with multiple spheres using different `MatteMaterial` colors (red, green, purple) — all previously appeared gray, now render with correct colors
- Rendered a materials gallery with 6 different materials (matte, diffuse, conductor) — all show distinct appearances

Created with the help of [Claude Code](https://claude.com/claude-code)